### PR TITLE
chore(ci): add Node 0.12, 4 & 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expect.js": "~0.2.0",
     "sinon": "~1.7.3",
     "sinon-expect": "~0.2.0",
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-simple-mocha": "~0.4.0",
     "matchdep": "~0.1.2"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": "~0.10.0"
   },
   "dependencies": {
-    "bluebird": "^3.1.1"
+    "bluebird": "~3.3.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/stream-worker.js
+++ b/stream-worker.js
@@ -19,7 +19,7 @@ module.exports = function(stream, concurrency, worker, cb) {
     });
 
     function errorHandler (err) {
-      firstError = firstError || err
+      firstError = firstError || err;
     }
 
     function finishTask (err) {

--- a/stream-worker.js
+++ b/stream-worker.js
@@ -19,11 +19,7 @@ module.exports = function(stream, concurrency, worker, cb) {
     });
 
     function errorHandler (err) {
-      if (err != null) {
-        if (firstError == null) {
-          firstError = err;
-        }
-      }
+      firstError = firstError || err
     }
 
     function finishTask (err) {

--- a/stream-worker.js
+++ b/stream-worker.js
@@ -13,7 +13,7 @@ module.exports = function(stream, concurrency, worker, cb) {
   return Promise.try(function() {
 
     var resolve, reject;
-    streamPromise = new Promise(function(__resolve, __reject) {
+    var streamPromise = new Promise(function(__resolve, __reject) {
       resolve = __resolve;
       reject = __reject;
     });


### PR DESCRIPTION
**Edit:** Ah, there's the sanity check I needed! I'll try to figure it out and commit a fix

Warnings from bluebird are not being shown in TravisCI logs, here's what's happening:

```
Warning: a promise was created in a handler but was not returned from it
    at C:\Users\Pier-Luc\Documents\GitHub\stream-worker\test\stream-worker.test.coffee:29:21
    at Function.invoke (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\node_modules\sinon\lib\sinon\spy.js:342:55)
    at proxy (eval at createProxy (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\node_modules\sinon\lib\sinon\spy.js:266:82), <anonymous>:1:35)
    at startNextTask (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\stream-worker.js:43:25)
    at finishTask (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\stream-worker.js:29:9)
    at C:\Users\Pier-Luc\Documents\GitHub\stream-worker\stream-worker.js:45:11
    at processImmediate [as _immediateCallback] (timers.js:383:17)
From previous event:
    at startNextTask (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\stream-worker.js:44:10)
    at PassThrough.<anonymous> (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\stream-worker.js:64:9)
    at emitOne (events.js:77:13)
    at PassThrough.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at PassThrough.Readable.push (_stream_readable.js:110:10)
    at PassThrough.Transform.push (_stream_transform.js:128:32)
    at afterTransform (_stream_transform.js:76:12)
    at TransformState.afterTransform (_stream_transform.js:54:12)
    at PassThrough._transform (_stream_passthrough.js:21:3)
    at PassThrough.Transform._read (_stream_transform.js:167:10)
    at PassThrough.Transform._write (_stream_transform.js:155:12)
    at doWrite (_stream_writable.js:292:12)
    at writeOrBuffer (_stream_writable.js:278:5)
    at PassThrough.Writable.write (_stream_writable.js:207:11)
    at Context.<anonymous> (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\test\stream-worker.test.coffee:54:34)
    at callFn (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\node_modules\mocha\lib\runnable.js:315:21)
    at Hook.Runnable.run (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\node_modules\mocha\lib\runnable.js:308:7)
    at next (C:\Users\Pier-Luc\Documents\GitHub\stream-worker\node_modules\mocha\lib\runner.js:298:10)
```
