### PR TITLE
Fix global 'streamPromise'

### DIFF
--- a/stream-worker.js
+++ b/stream-worker.js
@@ -13,7 +13,7 @@ module.exports = function(stream, concurrency, worker, cb) {
   return Promise.try(function() {
 
     var resolve, reject;
-    streamPromise = new Promise(function(__resolve, __reject) {
+    var streamPromise = new Promise(function(__resolve, __reject) {
       resolve = __resolve;
       reject = __reject;
     });


### PR DESCRIPTION
You know, because globals are bad and mocha.js doesn't like them either
