### PR TITLE
stream-worker should handle a stream emitting 'error' and then 'close' correctly

### DIFF
--- a/stream-worker.js
+++ b/stream-worker.js
@@ -26,6 +26,11 @@ module.exports = function(stream, concurrency, worker, cb) {
       }
     }
 
+    function closeHandler () {
+      closed = true;
+      completeIfDone();
+    }
+
     function finishTask (err) {
       running -= 1;
       errorHandler(err);
@@ -72,11 +77,8 @@ module.exports = function(stream, concurrency, worker, cb) {
     });
 
     stream.on('error', errorHandler);
-
-    stream.on('end', function() {
-      closed = true;
-      completeIfDone();
-    });
+    stream.on('close', closeHandler);
+    stream.on('end', closeHandler);
 
     return streamPromise;
   })

--- a/test/stream-worker.test.coffee
+++ b/test/stream-worker.test.coffee
@@ -208,3 +208,30 @@ describe 'stream-worker', ->
           Promise.resolve() # wait for async operations
           .then -> Promise.resolve() # wait again...
           .then -> expect(done).was.called()
+
+    describe 'when the stream is closed with an error after ending', ->
+      describe 'while workers are working', ->
+        beforeEach () ->
+          stream.write 'a'
+          stream.emit 'end'
+          # in case the underlying stream implementation emits both an
+          # end and error/close pair of events
+          stream.emit 'error', new Error('a')
+          stream.emit 'close'
+
+        it 'waits for all workers to finish, then calls the done callback', ->
+          expect(done).was.notCalled()
+          workers[0].done()
+          Promise.resolve() # wait for async operations
+          .then -> Promise.resolve() # wait again...
+          .then -> expect(done).was.calledOnce() # ensure only called once
+
+      describe 'before emitting any data', ->
+        beforeEach () ->
+          stream.emit 'error', new Error('a')
+          stream.emit 'close'
+
+        it 'still calls the done callback', ->
+          Promise.resolve() # wait for async operations
+          .then -> Promise.resolve() # wait again...
+          .then -> expect(done).was.calledOnce() # ensure only called once

--- a/test/stream-worker.test.coffee
+++ b/test/stream-worker.test.coffee
@@ -184,3 +184,27 @@ describe 'stream-worker', ->
           Promise.resolve() # wait for async operations
           .then -> Promise.resolve() # wait again...
           .then -> expect(done).was.called()
+
+    describe 'when the stream is closed with an error', ->
+      describe 'while workers are working', ->
+        beforeEach () ->
+          stream.write 'a'
+          stream.emit 'error', new Error('a')
+          stream.emit 'close'
+
+        it 'waits for all workers to finish, then calls the done callback', ->
+          expect(done).was.notCalled()
+          workers[0].done()
+          Promise.resolve() # wait for async operations
+          .then -> Promise.resolve() # wait again...
+          .then -> expect(done).was.called()
+
+      describe 'before emitting any data', ->
+        beforeEach () ->
+          stream.emit 'error', new Error('a')
+          stream.emit 'close'
+
+        it 'still calls the done callback', ->
+          Promise.resolve() # wait for async operations
+          .then -> Promise.resolve() # wait again...
+          .then -> expect(done).was.called()


### PR DESCRIPTION
One of the error cases with legacy streams is that the stream can be
closed via an error. In such cases, it is common for the underlying
stream to emit an `'error'` event, followed by a `'close'` event. In this
situation, stream worker should listen to the close event and consider
that closing the stream as well.

https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/stream.markdown#event-close
