### PR TITLE
Fixes #5 make promises/async part of the options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ var streamWorker = require('stream-worker');
 
 
 Promise style:
-
 ```js
-streamWorker(stream, 10, function(data) {
+function doWork(data){
   /* ... do some work with data ... */
   return Promise.resolve();
-})
+}
+streamWorker(stream, doWork, {promises : true, concurrency : 10})
 .then(function() {
   /* ... the stream is exhausted and all workers are finished ... */
 }, function(err) {
@@ -38,11 +38,12 @@ streamWorker(stream, 10, function(data) {
 Callback style:
 
 ```js
-streamWorker(stream, 10,
-  function(data, done) {
-    /* ... do some work with data ... */
-    done(err);
-  },
+
+function doWork(data, done){
+  /* ... do some work with data ... */
+  return done(err);;
+}
+streamWorker(stream, doWork, {promises : false, concurrency :10},
   function(err) {
     /* ... the stream is exhauseted and all workers are finished ... */
   }
@@ -51,4 +52,15 @@ streamWorker(stream, 10,
 
 Signature
 ---------
-streamWorker(**stream**, **concurrencyLimit**, **work**, **done**)
+streamWorker(**stream**, **work**, **options**, **done**)
+
+Where **options** is an object with 2 optional parameters:
+
+| Parameter     | Default       | Description|
+|------------- |-------------| -----|
+| promises      |false| true if you want to use the above promises style|
+| concurrency| 10|specifies how many concurrent workers you want doing work in the stream |
+
+And **done** is a callback function if you use the callback workflow.
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-worker",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Execute an async function per stream data event, pausing the stream when a concurrency limit is saturated",
   "main": "stream-worker.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "BSD",
   "devDependencies": {
     "expect.js": "~0.2.0",
-    "grunt": "^1.0.1",
+    "grunt": "^0.4.0",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-simple-mocha": "~0.4.0",
     "matchdep": "~0.1.2",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
   "license": "BSD",
   "devDependencies": {
     "expect.js": "~0.2.0",
-    "sinon": "~1.7.3",
-    "sinon-expect": "~0.2.0",
+    "grunt": "^1.0.1",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-simple-mocha": "~0.4.0",
-    "matchdep": "~0.1.2"
+    "matchdep": "~0.1.2",
+    "sinon": "~1.7.3",
+    "sinon-expect": "~0.2.0"
   },
   "engines": {
     "node": "~0.10.0"

--- a/stream-worker.js
+++ b/stream-worker.js
@@ -1,12 +1,24 @@
 var Promise = require('bluebird');
 
-module.exports = function(stream, concurrency, worker, cb) {
+
+/**
+ *
+ * @param {Stream} stream
+ * @param {Function} worker - work to be done on each data element of the stream
+ * @param {Object} options
+ * @param {Boolean} [options.promises=false] - if true, the worker operates using promises.
+ * @param {Number} [options.concurrency=10] - the maximum number of tasks to run concurrently
+ * @param {Function} [done] - if using callbacks, this is called when work on the stream finishes
+ */
+module.exports = function(stream, worker, options, done) {
   var tasks = [],
       running = 0,
       closed = false,
       firstError = null;
 
-  if (worker.length > 1) { // worker returns a callback
+  var promises = options.promises ? options.promises : false;
+  var concurrency = options.concurrency ? options.concurrency : 10;
+  if (promises === false) {
     worker = Promise.promisify(worker);
   }
 
@@ -82,5 +94,5 @@ module.exports = function(stream, concurrency, worker, cb) {
 
     return streamPromise;
   })
-  .asCallback(cb);
+  .asCallback(done);
 };

--- a/test/stream-worker.test.coffee
+++ b/test/stream-worker.test.coffee
@@ -19,8 +19,10 @@ describe 'stream-worker', ->
         promise = new Promise (__resolve) -> resolve = __resolve
         workers.push {data, done: resolve}
         promise
-
-      streamWorker(stream, concurrencyLimit, work).then(done)
+      options =
+        promises : true,
+        concurrency : concurrencyLimit
+      streamWorker(stream, work, options).then(done)
 
       return # so that we don't return a promise from the beforeEach block
 
@@ -106,8 +108,10 @@ describe 'stream-worker', ->
       done = sinon.spy()
       work = sinon.spy (data, workerDone) ->
         workers.push {data, done: workerDone}
-
-      streamWorker stream, concurrencyLimit, work, done
+      options =
+        concurrency : concurrencyLimit
+        promises : false
+      streamWorker stream, work, options, done
 
       return # so that we don't return a promise from the beforeEach block
 


### PR DESCRIPTION
Per the suggestion in #5 , I reworked the function signature to take an options object that specifies the async behavior and concurrency limit, with defaults promises : false and concurrency : 10. 

I also updated the README with new signature and reworked examples, and fixed up the tests. Let me know if you'd like additional tests.

Finally, I bumped the version in package.json and fixed an issue I was having where `npm install` didn't install grunt locally, which was necessary for `npm test`.

I'm a fan of the redundant-seeming style of `var promises = options.promises ? options.promises : false;`  even though options.promises should just be a proper bool or undefined, since it makes implicit behavior explicit, but feel free to edit/reject/comment on stylistic concerns.
