### PR TITLE
Resolve bluebird warnings for nothing returned from a promise

### DIFF
--- a/stream-worker.js
+++ b/stream-worker.js
@@ -60,17 +60,14 @@ module.exports = function(stream, worker, options, done) {
         completeIfDone();
       }
       running += 1;
-      try {
-        Promise.resolve(worker(data))
-        .then(function (finishedWith) {
-          finishTask();
-        })
-        .error(function (err) {
-          finishTask(err);
-        });
-      } catch (e) {
-        finishTask(e);
-      }
+      Promise.try(function() { return worker(data); })
+      .then(function (finishedWith) {
+        finishTask();
+        return null;
+      }, function (err) {
+        finishTask(err);
+        return null;
+      });
     }
 
     function completeIfDone () {


### PR DESCRIPTION
Use Promise.try to catch synchronous errors from worker instead of an outer try/catch. Also return null explicitly to silence [these](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it) warnings. 

@demands 
